### PR TITLE
Fix clippy --tests warnings

### DIFF
--- a/contracts/tfi-pair/src/testing.rs
+++ b/contracts/tfi-pair/src/testing.rs
@@ -670,24 +670,21 @@ fn try_native_to_token() {
         },
     )
     .unwrap();
-    assert_eq!(
+    assert!(
         (offer_amount.u128() as i128 - reverse_simulation_res.offer_amount.u128() as i128).abs()
-            < 5i128,
-        true
+            < 5i128
     );
-    assert_eq!(
+    assert!(
         (expected_commission_amount.u128() as i128
             - reverse_simulation_res.commission_amount.u128() as i128)
             .abs()
-            < 5i128,
-        true
+            < 5i128
     );
-    assert_eq!(
+    assert!(
         (expected_spread_amount.u128() as i128
             - reverse_simulation_res.spread_amount.u128() as i128)
             .abs()
-            < 5i128,
-        true
+            < 5i128
     );
 
     assert_eq!(
@@ -852,24 +849,21 @@ fn try_token_to_native() {
         },
     )
     .unwrap();
-    assert_eq!(
+    assert!(
         (offer_amount.u128() as i128 - reverse_simulation_res.offer_amount.u128() as i128).abs()
-            < 5i128,
-        true
+            < 5i128
     );
-    assert_eq!(
+    assert!(
         (expected_commission_amount.u128() as i128
             - reverse_simulation_res.commission_amount.u128() as i128)
             .abs()
-            < 5i128,
-        true
+            < 5i128
     );
-    assert_eq!(
+    assert!(
         (expected_spread_amount.u128() as i128
             - reverse_simulation_res.spread_amount.u128() as i128)
             .abs()
-            < 5i128,
-        true
+            < 5i128
     );
 
     assert_eq!(

--- a/packages/tfi/src/testing.rs
+++ b/packages/tfi/src/testing.rs
@@ -97,7 +97,7 @@ fn test_asset_info() {
     let token_info: AssetInfo = AssetInfo::Token(Addr::unchecked("asset0000"));
     let native_token_info: AssetInfo = AssetInfo::Native("uusd".to_string());
 
-    assert_eq!(false, token_info.equal(&native_token_info));
+    assert!(!token_info.equal(&native_token_info));
 
     assert_ne!(token_info, AssetInfo::Token(Addr::unchecked("asset0001")),);
 


### PR DESCRIPTION
A few minor things that showed up when testing under Rust 1.53