### PR TITLE
tfi-factory: non-empty label when instantiating tfi-pair

### DIFF
--- a/contracts/tfi-factory/src/contract.rs
+++ b/contracts/tfi-factory/src/contract.rs
@@ -106,10 +106,12 @@ pub fn execute_create_pair(
         },
     )?;
 
+    let pair_name = format!("{}-{}", asset_infos[0], asset_infos[1]);
+
     Ok(Response {
         attributes: vec![
             attr("action", "create_pair"),
-            attr("pair", format!("{}-{}", asset_infos[0], asset_infos[1])),
+            attr("pair", pair_name.clone()),
         ],
         messages: vec![SubMsg {
             id: 1,
@@ -118,7 +120,7 @@ pub fn execute_create_pair(
                 code_id: config.pair_code_id,
                 funds: vec![],
                 admin: None,
-                label: "".to_string(),
+                label: pair_name,
                 msg: to_binary(&PairInstantiateMsg {
                     asset_infos,
                     token_code_id: config.token_code_id,

--- a/contracts/tfi-factory/src/testing.rs
+++ b/contracts/tfi-factory/src/testing.rs
@@ -148,7 +148,7 @@ fn create_pair() {
                 .unwrap(),
                 code_id: 321u64,
                 funds: vec![],
-                label: "".to_string(),
+                label: "asset0000-asset0001".to_string(),
                 admin: None,
             }
             .into()


### PR DESCRIPTION
Contract used "", which was valid Rust, but not permitted by wasmd, which demands non-empty (not just non-null).

Fixed this by using a real label.