### PR TITLE
Multitest veryfing full tfi-factory workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,14 +818,23 @@ dependencies = [
 name = "tfi-factory"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
+ "cw-multi-test",
  "cw-storage-plus",
+ "cw20",
+ "cw20-base",
+ "cw4",
+ "cw4-group",
+ "derivative",
+ "dso-token",
  "protobuf",
  "schemars",
  "serde",
  "tfi",
+ "tfi-pair",
  "thiserror",
 ]
 

--- a/contracts/tfi-factory/Cargo.toml
+++ b/contracts/tfi-factory/Cargo.toml
@@ -34,3 +34,13 @@ thiserror = "1"
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
+anyhow = { version = "1", features = ["backtrace"] }
+cw-multi-test = "0.8.0"
+tfi-pair = { path = "../tfi-pair", version = "0.1" }
+dso-token = { path = "../dso-token", version = "0.2" }
+derivative = "2"
+cw4-group = { version = "0.8", features = ["library"] }
+cw4 = "0.8"
+cw20 = "0.8"
+cw20-base = { version = "0.8", features = ["library"] }
+

--- a/contracts/tfi-factory/src/contract.rs
+++ b/contracts/tfi-factory/src/contract.rs
@@ -178,8 +178,8 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> StdResult<Response> {
         &tmp_pair_info.pair_key,
         &PairInfo::new(
             tmp_pair_info.asset_infos,
-            liquidity_token.clone(),
             pair_contract.clone(),
+            liquidity_token.clone(),
         )
         .with_commission(tmp_pair_info.commission),
     )?;

--- a/contracts/tfi-factory/src/lib.rs
+++ b/contracts/tfi-factory/src/lib.rs
@@ -6,6 +6,8 @@ mod querier;
 mod response;
 
 #[cfg(test)]
+mod multitest;
+#[cfg(test)]
 mod testing;
 
 #[cfg(test)]

--- a/contracts/tfi-factory/src/multitest.rs
+++ b/contracts/tfi-factory/src/multitest.rs
@@ -1,0 +1,147 @@
+mod suite;
+
+use anyhow::Error;
+
+/// Compares if error is as expected
+///
+/// Unfortunatelly, error types information is lost, as in multitest every error is just converted
+/// to its string representation. To solve this issue and still be able to reasonably test returned
+/// error, but to avoid maintaining error string validation, errors are passed strongly typed, but
+/// verified on their representation level. Additionally when error doesn't match, the actuall
+/// error is printed in debug form so additional `anyhow` information is displayed.
+#[track_caller]
+fn assert_error(err: Error, expected: impl ToString + std::fmt::Debug) {
+    assert_eq!(
+        err.to_string(),
+        expected.to_string(),
+        "received error {:?} while expected {:?}",
+        err,
+        expected
+    );
+}
+
+/// The simplest full stack success flow test scenario
+///
+/// All actors are whitelisted. Single pair is created by factory, end then it is whitelisted. Then
+/// liquidity is provided, swaps in both directions are performed, and liquidity is whitedrawn.
+///
+/// No state checks are performed, only the fact that all operations successes. All logic is
+/// covered by UTs, and tfi-pair integration tests.
+#[test]
+fn everyone_whitelisted() {
+    let mut suite = suite::Config::new()
+        .with_actor("liquidity-provider", 2000, 6000, true)
+        .with_actor("trader", 1000, 1000, true)
+        .init()
+        .unwrap();
+
+    let (cash, lp, trader) = (
+        suite.cash.clone(),
+        suite.actors[0].clone(),
+        suite.actors[1].clone(),
+    );
+
+    let (pair, lt) = suite
+        .create_pair([suite.btc(), suite.cash()], None)
+        .unwrap();
+
+    suite
+        .add_member(&pair)
+        .unwrap()
+        .increase_allowance(&cash.addr(), &lp, &pair, 6000)
+        .unwrap()
+        .provide_liquidity(&pair, &lp, 2000, 6000)
+        .unwrap()
+        .swap_btc(&pair, &trader, 1000)
+        .unwrap()
+        .swap_cash(&pair, &trader, 1000)
+        .unwrap();
+
+    let share = lt.balance(&suite.app, &lp).unwrap();
+
+    suite
+        .withdraw_liquidity(&pair, &lt.addr(), &lp, share.into())
+        .unwrap();
+}
+
+/// Failure test showing up, that it is impossible to provide liquidity to pair if it is not part
+/// of the whitelist
+#[test]
+fn pair_not_whitelisted() {
+    let mut suite = suite::Config::new()
+        .with_actor("liquidity-provider", 2000, 6000, true)
+        .init()
+        .unwrap();
+
+    let (cash, lp) = (suite.cash.clone(), suite.actors[0].clone());
+
+    let (pair, _) = suite
+        .create_pair([suite.btc(), suite.cash()], None)
+        .unwrap();
+
+    let err = suite
+        .increase_allowance(&cash.addr(), &lp, &pair, 6000)
+        .unwrap()
+        .provide_liquidity(&pair, &lp, 2000, 6000)
+        .unwrap_err();
+
+    assert_error(err, dso_token::error::ContractError::Unauthorized {});
+}
+
+/// Failure test showing up, that it is impossible to provide liquidity nor swap with pair by
+/// non-whitelisted actors
+#[test]
+fn actors_not_whitelisted() {
+    let mut suite = suite::Config::new()
+        .with_actor("member-liquidity-provider", 2000, 6000, true)
+        .with_actor("liquidity-provider", 2000, 6000, false)
+        .with_actor("trader", 1000, 1000, false)
+        .init()
+        .unwrap();
+
+    let (cash, member_lp, lp, trader) = (
+        suite.cash.clone(),
+        suite.actors[0].clone(),
+        suite.actors[1].clone(),
+        suite.actors[2].clone(),
+    );
+
+    // Preparation
+    let (pair, _) = suite
+        .create_pair([suite.btc(), suite.cash()], None)
+        .unwrap();
+
+    suite
+        .add_member(&pair)
+        .unwrap()
+        .increase_allowance(&cash.addr(), &member_lp, &pair, 6000)
+        .unwrap()
+        .provide_liquidity(&pair, &member_lp, 2000, 6000)
+        .unwrap();
+
+    // Non-member liquidity provider cannot even increase allowance
+    let err = suite
+        .increase_allowance(&cash.addr(), &lp, &pair, 6000)
+        .unwrap_err();
+    assert_error(err, dso_token::error::ContractError::Unauthorized {});
+
+    // As non-member liquidity provider is not allowed to provide liquidity
+    let err = suite.provide_liquidity(&pair, &lp, 2000, 6000).unwrap_err();
+    assert_error(err, dso_token::error::ContractError::Unauthorized {});
+
+    // Even if lp is later added, he would need to increase allowance first, as previous attempt
+    // failed
+    let err = suite
+        .add_member(&lp)
+        .unwrap()
+        .provide_liquidity(&pair, &lp, 2000, 6000)
+        .unwrap_err();
+    assert_error(err, cw20_base::ContractError::NoAllowance {});
+
+    // Non whitelisted members has no swap rights
+    let err = suite.swap_btc(&pair, &trader, 1000).unwrap_err();
+    assert_error(err, dso_token::error::ContractError::Unauthorized {});
+
+    let err = suite.swap_cash(&pair, &trader, 1000).unwrap_err();
+    assert_error(err, dso_token::error::ContractError::Unauthorized {});
+}

--- a/contracts/tfi-factory/src/multitest/suite.rs
+++ b/contracts/tfi-factory/src/multitest/suite.rs
@@ -1,0 +1,466 @@
+use anyhow::{anyhow, Result};
+use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
+use cosmwasm_std::{coins, to_binary, Addr, Decimal, Empty, Uint128};
+use cw20::{Cw20Coin, Cw20Contract, Cw20ExecuteMsg};
+use cw4::{Cw4Contract, Member};
+use cw4_group::msg::ExecuteMsg as Cw4ExecuteMsg;
+use cw_multi_test::{App, BankKeeper, Contract, ContractWrapper, Executor};
+use derivative::Derivative;
+use tfi::asset::{Asset, AssetInfo, PairInfo};
+use tfi::factory::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use tfi::pair::{Cw20HookMsg, ExecuteMsg as PairExecuteMsg};
+
+fn mock_app() -> App {
+    let env = mock_env();
+    let api = MockApi::default();
+    let bank = BankKeeper::new();
+    let storage = MockStorage::new();
+
+    App::new(api, env.block, bank, storage)
+}
+
+fn contract_factory() -> Box<dyn Contract<Empty>> {
+    Box::new(
+        ContractWrapper::new(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        )
+        .with_reply(crate::contract::reply),
+    )
+}
+
+fn contract_pair() -> Box<dyn Contract<Empty>> {
+    Box::new(
+        ContractWrapper::new(
+            tfi_pair::contract::execute,
+            tfi_pair::contract::instantiate,
+            tfi_pair::contract::query,
+        )
+        .with_reply(tfi_pair::contract::reply),
+    )
+}
+
+fn contract_cw20() -> Box<dyn Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        cw20_base::contract::execute,
+        cw20_base::contract::instantiate,
+        cw20_base::contract::query,
+    ))
+}
+
+fn contract_token() -> Box<dyn Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        dso_token::contract::execute,
+        dso_token::contract::instantiate,
+        dso_token::contract::query,
+    ))
+}
+
+fn contract_group() -> Box<dyn Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        cw4_group::contract::execute,
+        cw4_group::contract::instantiate,
+        cw4_group::contract::query,
+    ))
+}
+
+/// Testing environment with:
+/// * single native token "btc"
+/// * single cw4-group used as whitelist
+/// * single dso-token "cash" using internal group
+/// * single tfi-factory
+/// * number of actors which are just address initialized with some "btc" and "cash"
+///
+/// Note, that only actors marked as whitelisted are initially on whitelist - none of owner,
+/// whitelist, cash nor factory are initiallt on whitelist
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct Suite {
+    /// Application mock
+    #[derivative(Debug = "ignore")]
+    pub app: App,
+    /// Special account for performing administrative executions
+    pub owner: Addr,
+    /// General purpose actors
+    pub actors: Vec<Addr>,
+    /// cw4 whitelist contract address
+    pub whitelist: Cw4Contract,
+    /// dso-token cash contract address
+    pub cash: Cw20Contract,
+    /// tfi-factory contract address
+    pub factory: Addr,
+}
+
+impl Suite {
+    /// Returns btc asset info
+    ///
+    /// Takes self only to have signature unified with `cash` so tests are more straightforward to
+    /// read
+    pub fn btc(&self) -> AssetInfo {
+        AssetInfo::Native("btc".to_owned())
+    }
+
+    /// Returns cash asset info
+    pub fn cash(&self) -> AssetInfo {
+        AssetInfo::Token(self.cash.addr())
+    }
+
+    /// Executes CreatePair on `factory`. Returns created pair address and its liquidity token
+    /// address.
+    pub fn create_pair(
+        &mut self,
+        asset_infos: [AssetInfo; 2],
+        commission: impl Into<Option<Decimal>>,
+    ) -> Result<(Addr, Cw20Contract)> {
+        self.app
+            .execute_contract(
+                self.owner.clone(),
+                self.factory.clone(),
+                &ExecuteMsg::CreatePair {
+                    asset_infos: asset_infos.clone(),
+                    commission: commission.into(),
+                },
+                &[],
+            )
+            .map_err(|err| anyhow!(err))?;
+
+        let res: PairInfo = self
+            .app
+            .wrap()
+            .query_wasm_smart(self.factory.clone(), &QueryMsg::Pair { asset_infos })?;
+
+        Ok((res.contract_addr, Cw20Contract(res.liquidity_token)))
+    }
+
+    /// Adds member to whitelist
+    pub fn add_member(&mut self, addr: &Addr) -> Result<&mut Self> {
+        self.app
+            .execute_contract(
+                self.owner.clone(),
+                self.whitelist.addr(),
+                &Cw4ExecuteMsg::UpdateMembers {
+                    add: vec![Member {
+                        addr: addr.to_string(),
+                        weight: 10,
+                    }],
+                    remove: vec![],
+                },
+                &[],
+            )
+            .map_err(|err| anyhow!(err))?;
+
+        Ok(self)
+    }
+
+    /// Executes increase allowance on cw20 contract
+    pub fn increase_allowance(
+        &mut self,
+        contract: &Addr,
+        owner: &Addr,
+        spender: &Addr,
+        amount: u128,
+    ) -> Result<&mut Self> {
+        self.app
+            .execute_contract(
+                owner.clone(),
+                contract.clone(),
+                &Cw20ExecuteMsg::IncreaseAllowance {
+                    spender: spender.to_string(),
+                    amount: amount.into(),
+                    expires: None,
+                },
+                &[],
+            )
+            .map_err(|err| anyhow!(err))?;
+
+        Ok(self)
+    }
+
+    /// Provides liquidity on given pair
+    pub fn provide_liquidity(
+        &mut self,
+        pair: &Addr,
+        liquidity_provider: &Addr,
+        btc: u128,
+        cash: u128,
+    ) -> Result<&mut Self> {
+        self.app
+            .execute_contract(
+                liquidity_provider.clone(),
+                pair.clone(),
+                &PairExecuteMsg::ProvideLiquidity {
+                    assets: [
+                        Asset {
+                            info: self.btc(),
+                            amount: btc.into(),
+                        },
+                        Asset {
+                            info: self.cash(),
+                            amount: cash.into(),
+                        },
+                    ],
+                    slippage_tolerance: None,
+                },
+                &coins(btc, "btc"),
+            )
+            .map_err(|err| anyhow!(err))?;
+        Ok(self)
+    }
+
+    /// Swaps btc for cash using given pair
+    pub fn swap_btc(&mut self, pair: &Addr, trader: &Addr, btc: u128) -> Result<&mut Self> {
+        self.app
+            .execute_contract(
+                trader.clone(),
+                pair.clone(),
+                &PairExecuteMsg::Swap {
+                    offer_asset: Asset {
+                        info: AssetInfo::Native("btc".to_owned()),
+                        amount: Uint128::new(btc),
+                    },
+                    belief_price: None,
+                    max_spread: None,
+                    to: None,
+                },
+                &coins(btc, "btc"),
+            )
+            .map_err(|err| anyhow!(err))?;
+
+        Ok(self)
+    }
+
+    /// Swap cash for btc using given pair
+    pub fn swap_cash(&mut self, pair: &Addr, trader: &Addr, cash: u128) -> Result<&mut Self> {
+        self.app
+            .execute_contract(
+                trader.clone(),
+                self.cash.addr(),
+                &cw20_base::msg::ExecuteMsg::Send {
+                    contract: pair.to_string(),
+                    amount: Uint128::new(cash),
+                    msg: to_binary(&Cw20HookMsg::Swap {
+                        belief_price: None,
+                        max_spread: None,
+                        to: None,
+                    })
+                    .unwrap(),
+                },
+                &[],
+            )
+            .map_err(|err| anyhow!(err))?;
+
+        Ok(self)
+    }
+
+    /// Withdraws liquidity from given pair
+    pub fn withdraw_liquidity(
+        &mut self,
+        pair: &Addr,
+        lt: &Addr,
+        lp: &Addr,
+        amount: u128,
+    ) -> Result<&mut Self> {
+        self.app
+            .execute_contract(
+                lp.clone(),
+                lt.clone(),
+                &cw20_base::msg::ExecuteMsg::Send {
+                    contract: pair.to_string(),
+                    amount: amount.into(),
+                    msg: to_binary(&Cw20HookMsg::WithdrawLiquidity {}).unwrap(),
+                },
+                &[],
+            )
+            .map_err(|err| anyhow!(err))?;
+
+        Ok(self)
+    }
+}
+
+/// Configuration of single actor
+struct ActorConfig {
+    /// Actor address
+    addr: String,
+    /// Initial cash amount
+    cash: u128,
+    /// Initial btc amount
+    btc: u128,
+    /// Is actor initially whitelisted?
+    whitelisted: bool,
+}
+
+/// Intermediate actor data
+struct Actor {
+    addr: Addr,
+    whitelisted: bool,
+}
+
+#[derive(Default)]
+pub struct Config {
+    /// Initial actors
+    actors: Vec<ActorConfig>,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_actor(
+        mut self,
+        addr: impl Into<String>,
+        btc: u128,
+        cash: u128,
+        whitelisted: bool,
+    ) -> Self {
+        self.actors.push(ActorConfig {
+            addr: addr.into(),
+            btc,
+            cash,
+            whitelisted,
+        });
+
+        self
+    }
+
+    /// Initializes actors
+    ///
+    /// Sets initial btc balance, and returns:
+    /// * actors data for further processing
+    /// * data to be passed as initial cash balance
+    ///
+    /// Actors data are pairs of:
+    /// * actor address
+    /// * flag if actor should be initiallt whitelisted
+    fn init_actors(actors: Vec<ActorConfig>, app: &mut App) -> Result<(Vec<Actor>, Vec<Cw20Coin>)> {
+        Ok(actors
+            .into_iter()
+            .map(|actor| -> Result<_> {
+                let addr = Addr::unchecked(&actor.addr);
+                app.init_bank_balance(&addr, coins(actor.btc, "btc"))
+                    .map_err(|err| anyhow!(err))?;
+
+                let initial_cash = Cw20Coin {
+                    address: addr.to_string(),
+                    amount: Uint128::new(actor.cash),
+                };
+
+                Ok((
+                    Actor {
+                        addr,
+                        whitelisted: actor.whitelisted,
+                    },
+                    initial_cash,
+                ))
+            })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .unzip())
+    }
+
+    /// Initializes whitelist contract basing on initial members
+    pub fn init_whitelist(
+        members: impl Iterator<Item = Addr>,
+        app: &mut App,
+        owner: &Addr,
+        cw4_id: u64,
+    ) -> Result<Cw4Contract> {
+        let members = members
+            .map(|addr| Member {
+                addr: addr.to_string(),
+                weight: 10,
+            })
+            .collect();
+
+        app.instantiate_contract(
+            cw4_id,
+            owner.clone(),
+            &cw4_group::msg::InstantiateMsg {
+                admin: Some(owner.to_string()),
+                members,
+            },
+            &[],
+            "Whitelist",
+            None,
+        )
+        .map(Cw4Contract)
+        .map_err(|err| anyhow!(err))
+    }
+
+    /// Initializes cash contract
+    fn init_cash(
+        initial_balances: Vec<Cw20Coin>,
+        whitelist: &Addr,
+        app: &mut App,
+        owner: &Addr,
+        cw20_id: u64,
+    ) -> Result<Cw20Contract> {
+        app.instantiate_contract(
+            cw20_id,
+            owner.clone(),
+            &dso_token::msg::InstantiateMsg {
+                name: "Cash Token".to_owned(),
+                symbol: "CASH".to_owned(),
+                decimals: 9,
+                initial_balances,
+                mint: None,
+                marketing: None,
+                whitelist_group: whitelist.to_string(),
+            },
+            &[],
+            "Cash",
+            None,
+        )
+        .map(Cw20Contract)
+        .map_err(|err| anyhow!(err))
+    }
+
+    /// Initializes factory contract
+    fn init_factory(
+        pair_id: u64,
+        cw20_id: u64,
+        app: &mut App,
+        owner: &Addr,
+        factory_id: u64,
+    ) -> Result<Addr> {
+        app.instantiate_contract(
+            factory_id,
+            owner.clone(),
+            &InstantiateMsg::new(pair_id, cw20_id),
+            &[],
+            "Factory",
+            None,
+        )
+        .map_err(|err| anyhow!(err))
+    }
+
+    pub fn init(self) -> Result<Suite> {
+        let mut app = mock_app();
+        let owner = Addr::unchecked("owner");
+        let cw4_id = app.store_code(contract_group());
+        let cw20_id = app.store_code(contract_cw20());
+        let token_id = app.store_code(contract_token());
+        let pair_id = app.store_code(contract_pair());
+        let factory_id = app.store_code(contract_factory());
+
+        let (actors, initial_cash) = Self::init_actors(self.actors, &mut app)?;
+        let members = actors
+            .iter()
+            .filter(|actor| actor.whitelisted)
+            .map(|actor| actor.addr.clone());
+        let whitelist = Self::init_whitelist(members, &mut app, &owner, cw4_id)?;
+        let actors = actors.into_iter().map(|actor| actor.addr).collect();
+        let cash = Self::init_cash(initial_cash, &whitelist.addr(), &mut app, &owner, token_id)?;
+        let factory = Self::init_factory(pair_id, cw20_id, &mut app, &owner, factory_id)?;
+
+        Ok(Suite {
+            app,
+            owner,
+            actors,
+            whitelist,
+            cash,
+            factory,
+        })
+    }
+}

--- a/contracts/tfi-factory/src/testing.rs
+++ b/contracts/tfi-factory/src/testing.rs
@@ -241,8 +241,8 @@ fn reply_test() {
         pair_res,
         PairInfo::new(
             asset_infos,
-            Addr::unchecked("liquidity0000"),
             Addr::unchecked("pair0000"),
+            Addr::unchecked("liquidity0000"),
         )
     );
 }


### PR DESCRIPTION
Closes #9

I didn't created proposed test with two separated groups, as I don't see reason for it - it is tested that if one is not a member of group related with token, it cannot trade, I don't see reason why to check if adding same member to completely unrelated group might change anything. Also this test would be more complicated than others. If there is real need for such test then I can spend more time to provide it.

One single bug is corrected with this PR as I found it with one of tests - arguments was swapped in one place, which caused creating invalid response for `Pair` query.

Also I am not sure about one thing - tfi-factory requires actual `cw20-base` contract to manage liquidity tokens. It is caused by fact, that it doesn't know about whitelists, so it is unable to instantiate liquidity token to be `dso-token`. I am not sure if it is by design, or just oversight.