### PR TITLE
[trusted-token] Fix multi-tests with `TgradeApp`

### DIFF
--- a/contracts/tfi-pair/src/multitest.rs
+++ b/contracts/tfi-pair/src/multitest.rs
@@ -276,7 +276,7 @@ impl Suite {
         assert_eq!(
             btc_balance,
             coin(btc, "btc"),
-            "Btc balace missmatch, expected: {}, actual: {}",
+            "Btc balance mismatch, expected: {}, actual: {}",
             btc,
             btc_balance.amount
         );
@@ -297,7 +297,7 @@ impl Suite {
             cw20::BalanceResponse {
                 balance: Uint128::new(cash)
             },
-            "Cash balance missmatch, expected: {}, actual: {}",
+            "Cash balance mismatch, expected: {}, actual: {}",
             cash,
             cash_balance.balance
         );
@@ -619,7 +619,7 @@ fn swap() {
     let mut suite = SuiteConfig::new()
         .with_liquidity_provider("liquidity-provider", 2000, 6000)
         .with_trader("trader", 1000, 0)
-        .with_trader("trader-recv", 0, 0)
+        .with_trader("trader-recv", 1, 1)
         .init()
         .unwrap();
 
@@ -637,7 +637,7 @@ fn swap() {
     suite
         .assert_balances(&lp, 0, 0, 3464)
         .assert_balances(&trader, 1000, 0, 0)
-        .assert_balances(&trader_recv, 0, 0, 0)
+        .assert_balances(&trader_recv, 1, 1, 0)
         .assert_balances(&pair, 2000, 6000, 0);
 
     suite.swap_btc(&trader, 1000, None, None, None).unwrap();
@@ -650,7 +650,7 @@ fn swap() {
     suite
         .assert_balances(&lp, 0, 0, 3464)
         .assert_balances(&trader, 0, 1994, 0)
-        .assert_balances(&trader_recv, 0, 0, 0)
+        .assert_balances(&trader_recv, 1, 1, 0)
         .assert_balances(&pair, 3000, 4006, 0);
 
     suite
@@ -665,7 +665,7 @@ fn swap() {
     suite
         .assert_balances(&lp, 0, 0, 3464)
         .assert_balances(&trader, 0, 994, 0)
-        .assert_balances(&trader_recv, 599, 0, 0)
+        .assert_balances(&trader_recv, 600, 1, 0)
         .assert_balances(&pair, 2401, 5006, 0);
 
     suite.withdraw_liquidity(&lp, 3464).unwrap();
@@ -679,7 +679,7 @@ fn swap() {
     suite
         .assert_balances(&lp, 2401, 5006, 0)
         .assert_balances(&trader, 0, 994, 0)
-        .assert_balances(&trader_recv, 599, 0, 0)
+        .assert_balances(&trader_recv, 600, 1, 0)
         .assert_balances(&pair, 0, 0, 0);
 }
 

--- a/contracts/trusted-token/src/multitest.rs
+++ b/contracts/trusted-token/src/multitest.rs
@@ -1,15 +1,12 @@
 mod suite;
 
-use cosmwasm_std::{Addr, Deps, Event, Uint128};
+use cosmwasm_std::{Addr, Event, Uint128};
 use cw20::{Cw20ReceiveMsg, TokenInfoResponse};
 
-use crate::contract::{verify_sender_and_addresses_on_whitelist, verify_sender_on_whitelist};
 use crate::error::ContractError;
 use crate::msg::{IsWhitelistedResponse, QueryMsg, WhitelistResponse};
 
-use crate::state::WHITELIST;
 use anyhow::Error;
-use cosmwasm_std::testing::{MockApi, MockStorage};
 
 /// Compares if error is as expected
 ///
@@ -95,38 +92,6 @@ fn burn() {
     assert_error(err, ContractError::Unauthorized {});
     assert_eq!(suite.balance(&member).unwrap(), 500);
     assert_eq!(suite.total_supply().unwrap(), 500);
-}
-
-#[test]
-fn whitelist_works() {
-    let suite = suite::Config::new()
-        .with_member("member", 1000, 10)
-        .with_member("member2", 1000, 0)
-        .init()
-        .unwrap();
-    let member = suite.members[0].clone();
-    let member2 = suite.members[1].clone();
-    let non_member = Addr::unchecked("nonmember");
-
-    // set our local data
-    let api = MockApi::default();
-    let mut storage = MockStorage::new();
-    WHITELIST.save(&mut storage, &suite.whitelist).unwrap();
-    let deps = Deps {
-        storage: &storage,
-        api: &api,
-        // querier is pointing to the app (with other contract initialized) for now
-        // we can remove the need for multi-test later
-        querier: suite.app.wrap(),
-    };
-
-    // sender whitelisted regardless of weight
-    verify_sender_on_whitelist(deps, &member).unwrap();
-    verify_sender_on_whitelist(deps, &member2).unwrap();
-    let err = verify_sender_on_whitelist(deps, &non_member).unwrap_err();
-    assert_eq!(err, ContractError::Unauthorized {});
-
-    verify_sender_and_addresses_on_whitelist(deps, &member, &[member2.as_str()]).unwrap();
 }
 
 #[test]

--- a/contracts/trusted-token/src/multitest/suite.rs
+++ b/contracts/trusted-token/src/multitest/suite.rs
@@ -2,7 +2,7 @@ use cw20_base::msg::InstantiateMarketingInfo;
 
 use cosmwasm_std::{to_binary, Addr, Binary, Empty, Response, StdError, Uint128};
 use cw20::{Cw20Coin, Cw20Contract, Cw20ReceiveMsg, MinterResponse, TokenInfoResponse};
-use cw_multi_test::{App, AppResponse, Contract, ContractWrapper, Executor};
+use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
 use tg4::{Member, Tg4Contract};
 use tg4_group::msg::ExecuteMsg as Tg4ExecuteMsg;
 use tg_bindings::TgradeMsg;
@@ -71,8 +71,8 @@ mod receiver {
         to_binary(&MESSAGES.load(deps.storage)?)
     }
 
-    pub fn contract() -> Box<dyn Contract<Empty>> {
-        let contract = ContractWrapper::new(execute, instantiate, query);
+    pub fn contract() -> Box<dyn Contract<TgradeMsg>> {
+        let contract = ContractWrapper::new_with_empty(execute, instantiate, query);
         Box::new(contract)
     }
 }
@@ -81,7 +81,7 @@ pub struct ReceiverContract(Addr);
 
 impl ReceiverContract {
     /// Helper for instantiating the contract
-    pub fn init(app: &mut App, owner: Addr) -> Result<Self> {
+    pub fn init(app: &mut TgradeApp, owner: Addr) -> Result<Self> {
         let id = app.store_code(receiver::contract());
         app.instantiate_contract(
             id,
@@ -100,15 +100,15 @@ impl ReceiverContract {
     }
 
     /// Helper for querying for stored messages
-    pub fn messages(&self, app: &App) -> Result<Vec<Cw20ReceiveMsg>> {
+    pub fn messages(&self, app: &TgradeApp) -> Result<Vec<Cw20ReceiveMsg>> {
         app.wrap()
             .query_wasm_smart(&self.0, &receiver::QueryMsg {})
             .map_err(|err| anyhow!(err))
     }
 }
 
-fn mock_app() -> App {
-    App::default()
+fn mock_app() -> TgradeApp {
+    TgradeApp::new("owner")
 }
 
 fn contract_group() -> Box<dyn Contract<TgradeMsg>> {
@@ -120,8 +120,8 @@ fn contract_group() -> Box<dyn Contract<TgradeMsg>> {
     Box::new(contract)
 }
 
-fn contract_cw20() -> Box<dyn Contract<Empty>> {
-    let contract = ContractWrapper::new(
+fn contract_cw20() -> Box<dyn Contract<TgradeMsg>> {
+    let contract = ContractWrapper::new_with_empty(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,
@@ -135,7 +135,7 @@ fn contract_cw20() -> Box<dyn Contract<Empty>> {
 pub struct Suite {
     /// Application mock
     #[derivative(Debug = "ignore")]
-    pub app: App,
+    pub app: TgradeApp,
     /// Special account for performing administrative execution
     pub owner: Addr,
     /// Members of whitelist

--- a/contracts/trusted-token/src/multitest/suite.rs
+++ b/contracts/trusted-token/src/multitest/suite.rs
@@ -1,6 +1,6 @@
 use cw20_base::msg::InstantiateMarketingInfo;
 
-use cosmwasm_std::{to_binary, Addr, Binary, Empty, Response, StdError, Uint128};
+use cosmwasm_std::{to_binary, Addr, Binary, Response, StdError, Uint128};
 use cw20::{Cw20Coin, Cw20Contract, Cw20ReceiveMsg, MinterResponse, TokenInfoResponse};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
 use tg4::{Member, Tg4Contract};


### PR DESCRIPTION
This is WIP for making `trusted-token` multitests work with `TgradeApp`.

Requires some local setup, as we moved the code away from this variant already:

- Required `poe-contracts` branch: https://github.com/confio/poe-contracts/tree/tgradeapp-querier-0.6.1
- Required `cw-plus` branch: https://github.com/CosmWasm/cw-plus/tree/multi-test-generic-deps-0.11.1

These basically have the fixes applied over the versions used by the original `tfi` code in this branch.

So, checkout all three, and then put this into the `tfi` workspace's Cargo.toml:
```
[patch.crates-io]
tg4 = { path = "../poe-contracts/packages/tg4" }
tg4-group = { path = "../poe-contracts/contracts/tg4-group" }
cw2 = { path = "../cw-plus/packages/cw2" }
cw20 = { path = "../cw-plus/packages/cw20" }
cw-multi-test = { path = "../cw-plus/packages/multi-test" }
cw-storage-plus = { path = "../cw-plus/packages/storage-plus" }
cw20-base = { path = "../cw-plus/contracts/cw20-base" }
tg-bindings = { path = "../poe-contracts/packages/bindings" }
tg-bindings-test = { path = "../poe-contracts/packages/bindings-test" }
```

And you should be able to reproduce the current error:
```
$ cd contracts/trusted-token/
$ cargo build
$ cargo test
   Compiling trusted-token v0.2.2 (/home/mauro/work/tfi/contracts/trusted-token)
error[E0308]: mismatched types
   --> contracts/trusted-token/src/multitest.rs:124:32
    |
124 |     verify_sender_on_whitelist(deps, &member).unwrap();
    |                                ^^^^ expected struct `cosmwasm_std::Empty`, found enum `TgradeQuery`
...
```