### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ## [Unreleased](https://github.com/confio/tfi/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/tfi/compare/v0.3.2...HEAD)
+[Full Changelog](https://github.com/confio/tfi/compare/v0.4.0...HEAD)
+
+## [v0.4.0](https://github.com/confio/tfi/tree/v0.4.0) (2022-06-04)
+
+[Full Changelog](https://github.com/confio/tfi/compare/v0.3.2...v0.4.0)
+
+**Closed issues:**
+
+- Set same "migrator" address for pair contracts as factory has [\#71](https://github.com/confio/tfi/issues/71)
+
+**Merged pull requests:**
+
+- Set admin for created pair contracts [\#76](https://github.com/confio/tfi/pull/76) ([maurolacy](https://github.com/maurolacy))
+- Update to latest cw-plus [\#75](https://github.com/confio/tfi/pull/75) ([maurolacy](https://github.com/maurolacy))
 
 ## [v0.3.2](https://github.com/confio/tfi/tree/v0.3.2) (2022-04-04)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,10 +48,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64ct"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
 
 [[package]]
 name = "block-buffer"
@@ -88,15 +100,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0-beta8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e70111e9701c3ec43bfbff0e523cd4cb115876b4d3433813436dd0934ee962"
+checksum = "5eb0afef2325df81aadbf9be1233f522ed8f6e91df870c764bc44cca2b1415bd"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -107,18 +119,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0-beta8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc2ad5d86be5f6068833f63e20786768db6890019c095dd7775232184fb7b3"
+checksum = "4b36e527620a2a3e00e46b6e731ab6c9b68d11069c986f7d7be8eba79ef081a4"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0-beta8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d75f6a05667d8613b24171ef2c77a8bf6fb9c14f9e3aaa39aa10e0c6416ed67"
+checksum = "772e80bbad231a47a2068812b723a1ff81dd4a0d56c9391ac748177bea3a61da"
 dependencies = [
  "schemars",
  "serde_json",
@@ -126,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0-beta8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915ca82bd944f116f3a9717481f3fa657e4a73f28c4887288761ebb24e6fbe10"
+checksum = "875994993c2082a6fcd406937bf0fca21c349e4a624f3810253a14fa83a3a195"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -143,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0-beta8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4be9fd8c9d3ae7d0c32a925ecbc20707007ce0cba1f7538c0d78b7a2d3729b"
+checksum = "d18403b07304d15d304dad11040d45bbcaf78d603b4be3fb5e2685c16f9229b5"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -168,9 +180,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -203,13 +215,13 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "0.11.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bfeaf55f8dba5646cc3daddce17cd23a60f8e0c3fbacbe6735d287d7a6e33a"
+checksum = "4f0bc6019b4d3d81e11f5c384bcce7173e2210bd654d75c6c9668e12cca05dfa"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.11.1",
- "cw-utils 0.11.1",
+ "cw-storage-plus",
+ "cw-utils",
  "schemars",
  "serde",
  "thiserror",
@@ -217,15 +229,15 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbea57e5be4a682268a5eca1a57efece57a54ff216bfd87603d5e864aad40e12"
+checksum = "a3f9a8ab7c3c29ec93cb7a39ce4b14a05e053153b4a17ef7cf2246af1b7c087e"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.13.2",
- "cw-utils 0.13.2",
+ "cw-storage-plus",
+ "cw-utils",
  "derivative",
  "itertools",
  "prost",
@@ -236,20 +248,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.11.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7ee1963302b0ac2a9d42fe0faec826209c17452bfd36fbfd9d002a88929261"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw-storage-plus"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9336ecef1e19d56cf6e3e932475fc6a3dee35eec5a386e07917a1d1ba6bb0e35"
+checksum = "648b1507290bbc03a8d88463d7cd9b04b1fa0155e5eef366c4fa052b9caaac7a"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -258,21 +259,9 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.11.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef842a1792e4285beff7b3b518705f760fa4111dc1e296e53f3e92d1ef7f6220"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw-utils"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babd2c090f39d07ce5bf2556962305e795daa048ce20a93709eb591476e4a29e"
+checksum = "9dbaecb78c8e8abfd6b4258c7f4fbeb5c49a5e45ee4d910d3240ee8e1d714e1b"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -282,50 +271,38 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.11.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d81d7c359d6c1fba3aa83dad7ec6f999e512571380ae62f81257c3db569743"
+checksum = "04cf4639517490dd36b333bbd6c4fbd92e325fd0acf4683b41753bc5eb63bfc1"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.11.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw2"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993df11574f29574dd443eb0c189484bb91bc0638b6de3e32ab7f9319c92122d"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.13.2",
+ "cw-storage-plus",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw20"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356d364602c5fe763544ea00d485b825d6ef519a2fc6a3145528d7df3a603f40"
+checksum = "4cb782b8f110819a4eb5dbbcfed25ffba49ec16bbe32b4ad8da50a5ce68fec05"
 dependencies = [
  "cosmwasm-std",
- "cw-utils 0.13.2",
+ "cw-utils",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw20-base"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b370e5fb6b35db58cabd7903b8f9bd4c3bcff701c63bf1a7185a84e60bfa502"
+checksum = "0306e606581f4fb45e82bcbb7f0333179ed53dd949c6523f01a99b4bfc1475a0"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.13.2",
- "cw-utils 0.13.2",
- "cw2 0.13.2",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
  "cw20",
  "schemars",
  "serde",
@@ -334,21 +311,21 @@ dependencies = [
 
 [[package]]
 name = "cw4"
-version = "0.11.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41445666e3f6284c72f569b2240bb52d0add94bb448e169d30ae28fe000cfaeb"
+checksum = "0acc3549d5ce11c6901b3a676f2e2628684722197054d97cd0101ea174ed5cbd"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.11.1",
+ "cw-storage-plus",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "der"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid",
 ]
@@ -381,13 +358,13 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.12.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713c32426287891008edb98f8b5c6abb2130aa043c93a818728fcda78606f274"
+checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
 dependencies = [
  "der",
  "elliptic-curve",
- "hmac",
+ "rfc6979",
  "signature",
 ]
 
@@ -414,25 +391,27 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.5"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
+checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
 dependencies = [
+ "base16ct",
  "crypto-bigint",
+ "der",
  "ff",
  "generic-array",
  "group",
- "pkcs8",
  "rand_core 0.6.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
+checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -484,9 +463,9 @@ checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -535,13 +514,14 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "k256"
-version = "0.9.6"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
+checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "sec1",
  "sha2",
 ]
 
@@ -593,12 +573,13 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
  "der",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
@@ -670,6 +651,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+dependencies = [
+ "crypto-bigint",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +698,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+dependencies = [
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042ac496d97e5885149d34139bad1d617192770d7eb8f1866da2317ff4501853"
+checksum = "479b4dbc401ca13ee8ce902851b834893251404c4f3c65370a49e047a6be09a5"
 dependencies = [
  "serde",
 ]
@@ -781,10 +786,11 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
+ "base64ct",
  "der",
 ]
 
@@ -813,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "tfi"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -826,15 +832,15 @@ dependencies = [
 
 [[package]]
 name = "tfi-factory"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
- "cw-storage-plus 0.13.2",
- "cw2 0.13.2",
+ "cw-storage-plus",
+ "cw2",
  "cw20",
  "cw20-base",
  "derivative",
@@ -851,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "tfi-mocks"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -863,15 +869,15 @@ dependencies = [
 
 [[package]]
 name = "tfi-pair"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
- "cw-storage-plus 0.13.2",
- "cw2 0.13.2",
+ "cw-storage-plus",
+ "cw2",
  "cw20",
  "cw20-base",
  "derivative",
@@ -885,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings"
-version = "0.6.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5f33e3cca75cd7b71dab33a88e00e5b7aee2229c5d5b0809537e48fd328265"
+checksum = "9796e08cfc0990eb23785faa0185f4dc569fa4ec6d853c355d16d2d8d40d824b"
 dependencies = [
  "base64",
  "cosmwasm-std",
@@ -898,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "tg4"
-version = "0.6.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf67429cd808a9d621ef95350f075b0f9fdb66a1fe16985e19c43d98a2b1341"
+checksum = "349e92dce978b42329709546ab0c32684a6061229cca464f2859dea80a096584"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -910,15 +916,15 @@ dependencies = [
 
 [[package]]
 name = "tg4-group"
-version = "0.6.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d098bc842cd7cd7773585080b2bce24d614019a13cac1eebf2f9864f07b86e8b"
+checksum = "fefb92ab9ccbf23ce4a14dabc7ce775db9bef635d415cd58821ea31228df20cb"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
- "cw-storage-plus 0.11.1",
- "cw-utils 0.11.1",
- "cw2 0.11.1",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
  "cw4",
  "schemars",
  "serde",
@@ -948,14 +954,14 @@ dependencies = [
 
 [[package]]
 name = "trusted-token"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus 0.13.2",
- "cw2 0.13.2",
+ "cw-storage-plus",
+ "cw2",
  "cw20",
  "cw20-base",
  "derivative",

--- a/contracts/tfi-factory/Cargo.toml
+++ b/contracts/tfi-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfi-factory"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Confio GmbH", "Terraform Labs, PTE."]
 edition = "2018"
 description = "A tfi factory contract - auto pair contract generator and also directory for all pairs"
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-tfi = { path = "../../packages/tfi", default-features = false, version = "0.3.2"}
+tfi = { path = "../../packages/tfi", default-features = false, version = "0.4.0"}
 cosmwasm-std = "1.0.0"
 cw2 = "0.13.4"
 cw-storage-plus = "0.13.4"
@@ -37,8 +37,8 @@ cosmwasm-schema = "1.0.0"
 cosmwasm-storage = "1.0.0"
 anyhow = { version = "1", features = ["backtrace"] }
 cw-multi-test = "0.13.4"
-tfi-pair = { path = "../tfi-pair", version = "0.3.2" }
-trusted-token = { path = "../trusted-token", version = "0.3.2" }
+tfi-pair = { path = "../tfi-pair", version = "0.4.0" }
+trusted-token = { path = "../trusted-token", version = "0.4.0" }
 derivative = "2"
 tg4 = "0.10.0"
 tg4-group = { version = "0.10.0", features = ["library"] }

--- a/contracts/tfi-factory/Cargo.toml
+++ b/contracts/tfi-factory/Cargo.toml
@@ -40,7 +40,7 @@ cw-multi-test = "0.13.4"
 tfi-pair = { path = "../tfi-pair", version = "0.3.2" }
 trusted-token = { path = "../trusted-token", version = "0.3.2" }
 derivative = "2"
-tg4 = "0.6.2"
-tg4-group = { version = "0.6.2", features = ["library"] }
+tg4 = "0.10.0"
+tg4-group = { version = "0.10.0", features = ["library"] }
 cw20 = "0.13.4"
 cw20-base = { version = "0.13.4", features = ["library"] }

--- a/contracts/tfi-factory/Cargo.toml
+++ b/contracts/tfi-factory/Cargo.toml
@@ -24,23 +24,23 @@ backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 tfi = { path = "../../packages/tfi", default-features = false, version = "0.3.2"}
-cosmwasm-std = "1.0.0-beta8"
-cw2 = "0.13.2"
-cw-storage-plus = "0.13.2"
+cosmwasm-std = "1.0.0"
+cw2 = "0.13.4"
+cw-storage-plus = "0.13.4"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 protobuf = { version = "2", features = ["with-bytes"] }
 thiserror = "1"
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0-beta8"
-cosmwasm-storage = "1.0.0-beta8"
+cosmwasm-schema = "1.0.0"
+cosmwasm-storage = "1.0.0"
 anyhow = { version = "1", features = ["backtrace"] }
-cw-multi-test = "0.13.2"
+cw-multi-test = "0.13.4"
 tfi-pair = { path = "../tfi-pair", version = "0.3.2" }
 trusted-token = { path = "../trusted-token", version = "0.3.2" }
 derivative = "2"
 tg4 = "0.6.2"
 tg4-group = { version = "0.6.2", features = ["library"] }
-cw20 = "0.13.2"
-cw20-base = { version = "0.13.2", features = ["library"] }
+cw20 = "0.13.4"
+cw20-base = { version = "0.13.4", features = ["library"] }

--- a/contracts/tfi-factory/src/multitest/suite.rs
+++ b/contracts/tfi-factory/src/multitest/suite.rs
@@ -152,6 +152,7 @@ impl Suite {
                     add: vec![Member {
                         addr: addr.to_string(),
                         points: 10,
+                        start_height: None,
                     }],
                     remove: vec![],
                 },
@@ -386,6 +387,7 @@ impl Config {
             .map(|addr| Member {
                 addr: addr.to_string(),
                 points: 10,
+                start_height: None,
             })
             .collect();
 

--- a/contracts/tfi-factory/src/testing.rs
+++ b/contracts/tfi-factory/src/testing.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::{
-    attr, from_binary, to_binary, Addr, Decimal, Reply, ReplyOn, StdError, SubMsg,
-    SubMsgExecutionResponse, SubMsgResult, WasmMsg,
+    attr, from_binary, to_binary, Addr, Decimal, Reply, ReplyOn, StdError, SubMsg, SubMsgResponse,
+    SubMsgResult, WasmMsg,
 };
 
 use tfi::asset::{AssetInfo, PairInfo};
@@ -206,7 +206,7 @@ fn reply_test() {
 
     let reply_msg = Reply {
         id: 1,
-        result: SubMsgResult::Ok(SubMsgExecutionResponse {
+        result: SubMsgResult::Ok(SubMsgResponse {
             events: vec![],
             data: Some(vec![10, 8, 112, 97, 105, 114, 48, 48, 48, 48].into()),
         }),

--- a/contracts/tfi-pair/Cargo.toml
+++ b/contracts/tfi-pair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfi-pair"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Confio GmbH", "Terraform Labs, PTE."]
 edition = "2018"
 description = "A tfi pair contract"
@@ -24,7 +24,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 integer-sqrt = "0.1.5"
-tfi = { path = "../../packages/tfi", default-features = false, version = "0.3.2"}
+tfi = { path = "../../packages/tfi", default-features = false, version = "0.4.0"}
 cw2 = "0.13.4"
 cw20 = "0.13.4"
 cosmwasm-std = "1.0.0"
@@ -38,6 +38,6 @@ cosmwasm-schema = "1.0.0"
 cosmwasm-storage = "1.0.0"
 cw20-base = { version = "0.13.4", features = ["library"] }
 cw-multi-test = "0.13.4"
-tfi-mocks = { path = "../../packages/mocks", version = "0.3.2"}
+tfi-mocks = { path = "../../packages/mocks", version = "0.4.0"}
 derivative = "2"
 anyhow = { version = "1", features = ["backtrace"] }

--- a/contracts/tfi-pair/Cargo.toml
+++ b/contracts/tfi-pair/Cargo.toml
@@ -25,19 +25,19 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 integer-sqrt = "0.1.5"
 tfi = { path = "../../packages/tfi", default-features = false, version = "0.3.2"}
-cw2 = "0.13.2"
-cw20 = "0.13.2"
-cosmwasm-std = "1.0.0-beta8"
-cw-storage-plus = "0.13.2"
+cw2 = "0.13.4"
+cw20 = "0.13.4"
+cosmwasm-std = "1.0.0"
+cw-storage-plus = "0.13.4"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0-beta8"
-cosmwasm-storage = "1.0.0-beta8"
-cw20-base = { version = "0.13.2", features = ["library"] }
-cw-multi-test = "0.13.2"
+cosmwasm-schema = "1.0.0"
+cosmwasm-storage = "1.0.0"
+cw20-base = { version = "0.13.4", features = ["library"] }
+cw-multi-test = "0.13.4"
 tfi-mocks = { path = "../../packages/mocks", version = "0.3.2"}
 derivative = "2"
 anyhow = { version = "1", features = ["backtrace"] }

--- a/contracts/tfi-pair/src/testing.rs
+++ b/contracts/tfi-pair/src/testing.rs
@@ -8,7 +8,7 @@ use crate::math::{decimal_multiplication, reverse_decimal};
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     attr, to_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Reply, ReplyOn, Response, StdError,
-    SubMsg, SubMsgExecutionResponse, SubMsgResult, Uint128, WasmMsg,
+    SubMsg, SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg, MinterResponse};
 use tfi::asset::{Asset, AssetInfo, PairInfo};
@@ -65,7 +65,7 @@ fn proper_initialization() {
     // store liquidity token
     let reply_msg = Reply {
         id: 1,
-        result: SubMsgResult::Ok(SubMsgExecutionResponse {
+        result: SubMsgResult::Ok(SubMsgResponse {
             events: vec![],
             data: Some(
                 vec![
@@ -142,7 +142,7 @@ fn provide_liquidity() {
     // store liquidity token
     let reply_msg = Reply {
         id: 1,
-        result: SubMsgResult::Ok(SubMsgExecutionResponse {
+        result: SubMsgResult::Ok(SubMsgResponse {
             events: vec![],
             data: Some(
                 vec![
@@ -497,7 +497,7 @@ fn withdraw_liquidity() {
     // store liquidity token
     let reply_msg = Reply {
         id: 1,
-        result: SubMsgResult::Ok(SubMsgExecutionResponse {
+        result: SubMsgResult::Ok(SubMsgResponse {
             events: vec![],
             data: Some(
                 vec![
@@ -610,7 +610,7 @@ fn try_native_to_token() {
     // store liquidity token
     let reply_msg = Reply {
         id: 1,
-        result: SubMsgResult::Ok(SubMsgExecutionResponse {
+        result: SubMsgResult::Ok(SubMsgResponse {
             events: vec![],
             data: Some(
                 vec![
@@ -772,7 +772,7 @@ fn try_token_to_native() {
     // store liquidity token
     let reply_msg = Reply {
         id: 1,
-        result: SubMsgResult::Ok(SubMsgExecutionResponse {
+        result: SubMsgResult::Ok(SubMsgResponse {
             events: vec![],
             data: Some(
                 vec![
@@ -1001,7 +1001,7 @@ fn test_query_pool() {
     // store liquidity token
     let reply_msg = Reply {
         id: 1,
-        result: SubMsgResult::Ok(SubMsgExecutionResponse {
+        result: SubMsgResult::Ok(SubMsgResponse {
             events: vec![],
             data: Some(
                 vec![

--- a/contracts/trusted-token/Cargo.toml
+++ b/contracts/trusted-token/Cargo.toml
@@ -25,7 +25,7 @@ cosmwasm-std = "1.0.0"
 cw-storage-plus = "0.13.4"
 cw20-base = { version = "0.13.4", features = ["library"] }
 cw2 = "0.13.4"
-tg4 = "0.6.2"
+tg4 = "0.10.0"
 cw20 = "0.13.4"
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
@@ -36,4 +36,4 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0"
 cw-multi-test = "0.13.4"
 derivative = "2"
-tg4-group = { version = "0.6.2", features = ["library"] }
+tg4-group = { version = "0.10.0", features = ["library"] }

--- a/contracts/trusted-token/Cargo.toml
+++ b/contracts/trusted-token/Cargo.toml
@@ -21,19 +21,19 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = "1.0.0-beta8"
-cw-storage-plus = "0.13.2"
-cw20-base = { version = "0.13.2", features = ["library"] }
-cw2 = "0.13.2"
+cosmwasm-std = "1.0.0"
+cw-storage-plus = "0.13.4"
+cw20-base = { version = "0.13.4", features = ["library"] }
+cw2 = "0.13.4"
 tg4 = "0.6.2"
-cw20 = "0.13.2"
+cw20 = "0.13.4"
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.24" }
 
 [dev-dependencies]
 anyhow = "1"
-cosmwasm-schema = "1.0.0-beta8"
-cw-multi-test = "0.13.2"
+cosmwasm-schema = "1.0.0"
+cw-multi-test = "0.13.4"
 derivative = "2"
 tg4-group = { version = "0.6.2", features = ["library"] }

--- a/contracts/trusted-token/Cargo.toml
+++ b/contracts/trusted-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-token"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Confio GmbH"]
 edition = "2018"
 license = "Apache-2.0"

--- a/contracts/trusted-token/README.md
+++ b/contracts/trusted-token/README.md
@@ -10,7 +10,7 @@ Only whitelisted users will be able to add liquidity to the token, and trade it.
 
 ### Instantiation
 
-Instantiate message consist additional `whitelist_group`:
+Instantiate message contains an additional `whitelist_group`:
 
 ```rust
 pub struct InstantiateMsg {
@@ -24,13 +24,13 @@ pub struct InstantiateMsg {
 }
 ```
 
-New field is the address of cw4 group contract. Only addresses being members of
+This new field is the address of tg4 group contract. Only addresses that are members of
 this group would be able to trade this token.
 
 ### Execution
 
-We override the `execute` method and check that all addresses (sender, recipient, owner if sending on someone else's behalf)
-are members of the whitelist contract before dispatching to the standard `cw20-base` action.  This looks like:
+We override the `execute` method and check that all addresses (sender, recipient, and owner if sending on someone else's behalf)
+are members of the whitelist contract, before dispatching to the standard `cw20-base` action.  This looks like:
 
 ```rust
 pub fn execute() {
@@ -41,7 +41,7 @@ pub fn execute() {
     }
     // other variants....
   };
-  // rest of code...
+  // rest of the code...
 }
 ```
 
@@ -70,9 +70,9 @@ pub(crate) fn verify_sender_and_addresses_on_whitelist(
 }
 ```
 
-Note that it just checks if the member is present in the group contract, it is unimportant what weight it has.
-This means that even 0 weight (which will not allow it to vote in voting contracts) is sufficient to pass the whitelist.
-It must be fully removed from the group contract to no longer pass the whitelisting check.
+Note that this just checks if the member is present in the group contract; it is unimportant what weight it has.
+This means that even 0 weight members (which would not allow them to vote in voting contracts) can pass the whitelist.
+A member must be fully removed from the group contract to no longer pass the whitelisting check.
 
 ## New messages
 
@@ -89,22 +89,22 @@ It must be fully removed from the group contract to no longer pass the whitelist
 }
 ```
 
-Executing redeem on this contract effectively burns owned tokens. It is intended
-to redeem tokens to provider as part of offchain transaction, typically when he
-covers burned token value in other commodity.
+Executing redeem on this contract effectively burns the owned tokens. It is intended
+to redeem tokens to the provider as part of off-chain transaction; typically when he
+covers the burned token value in another commodity.
 
-`code` field is a value agreed with token provider to perform redeem with, to
-allow him to easly identify redeem operation. Any code can be used only for single
+The `code` field is a value agreed with token provider to perform redeem with, to
+allow him to easily identify the redeem operation. A code can only be used for a single
 redeem operation.
 
-`sender` is account which requested redeem, if it is not the same who executed it.
-It is optional, and message sender is used if none is provided.
+`sender` is the account who requested `Redeem`, if it is not the same who executed it.
+It is optional, and the message sender is used if none is provided.
 
-`memo` is free text field where extra metadata or just message can be embeded.
+`memo` is a free text field where an extra metadata or message can be embedded.
 
-When `Redeem` operation is completed, infomation about it is stored in contract
-state, so it can be later queried by token provider. Also custom event is send
-to blockchain:
+When the `Redeem` operation is completed, information about it is stored in contract
+state, so that it can be later queried by the token provider. Also, a custom event is sent
+to the blockchain:
 
 ```json
 {
@@ -117,8 +117,8 @@ to blockchain:
 }
 ```
 
-To finalize off-chain redeem operation, token provider might either subscribe on
-`redeem` event, or periodically query for redeems.
+To finalize an off-chain redeem operation, the token provider might either subscribe to
+the `redeem` event, or periodically query for redeems.
 
 ### RemoveRedeems
 
@@ -133,7 +133,7 @@ To finalize off-chain redeem operation, token provider might either subscribe on
 }
 ```
 
-Removes stored redeems information related to provided redeem codes. Only minter
+Removes stored redeem information related to the provided redeem codes. Only the minter
 is allowed to do that.
 
 ### CleanRedeems
@@ -142,7 +142,7 @@ is allowed to do that.
 { "clean_redeems" : {} }
 ```
 
-Removes all stored redeems information. Only minter is allowed to do that.
+Removes all stored redeems information. Only the minter is allowed to do that.
 
 ## New queries
 
@@ -171,11 +171,11 @@ Returns:
 }
 ```
 
-Queries for single redeem information. Besides of information provided by
-`redeem` event, `timestamp` field is added to give an idea when redeem took place.
+Queries for single redeem information. Besides information provided by the
+`redeem` event, a `timestamp` field is added to give an idea of when the redeem took place.
 
-Response may be empty, not containing `redeem` field, which means, that not
-redeem was performed with this code.
+The response may be empty, not containing a `redeem` field, which means that no
+redemption was performed with this code.
 
 ### Query for all redeems
 
@@ -206,9 +206,10 @@ Returns:
 }
 ```
 
-Queries for multiple redeems information. `redeems` field may contains multiple
-entries, but up to `limit`. If `limit` is not provided, it is still possible,
-that not all redeems are returned, it may be internal cap on items returned. To
-ensure that is not a case, additional query with `start_after` set as last
-retuned redeem code. If optional `start_after` is provided, then only items after
-this item would be returned.
+Queries for multiple redeems information. The `redeems` field may contain multiple
+entries, up to `limit`. If `limit` is not provided, it is still possible
+that not all redeems are returned, as there may be an internal cap on the
+numer of returned items per query. To ensure that that is not a case, an additional query
+with `start_after` set as the last returned redeem code can be performed.
+If an optional `start_after` is provided, then only items after
+this item will be returned.

--- a/contracts/trusted-token/schema/instantiate_msg.json
+++ b/contracts/trusted-token/schema/instantiate_msg.json
@@ -48,7 +48,7 @@
       "type": "string"
     },
     "whitelist_group": {
-      "description": "This is the address of a cw4 compatible contract that will serve as a whitelist",
+      "description": "This is the address of a tg4 compatible contract that will serve as a whitelist",
       "type": "string"
     }
   },

--- a/contracts/trusted-token/schema/query_msg.json
+++ b/contracts/trusted-token/schema/query_msg.json
@@ -3,7 +3,7 @@
   "title": "QueryMsg",
   "anyOf": [
     {
-      "description": "Returns the cw4 contract used to whitelist this token. Return type: WhitelistResponse",
+      "description": "Returns the tg4 contract used to whitelist this token. Return type: WhitelistResponse",
       "type": "object",
       "required": [
         "whitelist"

--- a/contracts/trusted-token/src/contract.rs
+++ b/contracts/trusted-token/src/contract.rs
@@ -49,7 +49,7 @@ pub fn instantiate(
 
     let addr = deps.api.addr_validate(&msg.whitelist_group)?;
     let contract = Tg4Contract(addr.clone());
-    // verify the whitelist contract is actually cw4
+    // verify that the whitelist contract is actually tg4-compatible
     contract.list_members(&deps.querier, None, Some(1))?;
     WHITELIST.save(deps.storage, &contract)?;
 

--- a/contracts/trusted-token/src/contract.rs
+++ b/contracts/trusted-token/src/contract.rs
@@ -390,11 +390,11 @@ mod tests {
     };
     use cw20_base::state::TokenInfo;
     use cw_storage_plus::Map;
-    use tg4::{MemberListResponse, Tg4QueryMsg};
+    use tg4::{MemberInfo, MemberListResponse, Tg4QueryMsg};
 
     use std::marker::PhantomData;
 
-    const MEMBERS: Map<&Addr, u64> = Map::new(tg4::MEMBERS_KEY);
+    const MEMBERS: Map<&Addr, MemberInfo> = Map::new(tg4::MEMBERS_KEY);
 
     struct GroupQuerier {
         contract: String,
@@ -405,7 +405,9 @@ mod tests {
         pub fn new(contract: &Addr, members: &[(&Addr, u64)]) -> Self {
             let mut storage = MockStorage::new();
             for (member, weight) in members {
-                MEMBERS.save(&mut storage, member, weight).unwrap();
+                MEMBERS
+                    .save(&mut storage, member, &MemberInfo::new(*weight))
+                    .unwrap();
             }
             GroupQuerier {
                 contract: contract.to_string(),

--- a/contracts/trusted-token/src/msg.rs
+++ b/contracts/trusted-token/src/msg.rs
@@ -14,7 +14,7 @@ pub struct InstantiateMsg {
     pub initial_balances: Vec<Cw20Coin>,
     pub mint: Option<MinterResponse>,
     pub marketing: Option<InstantiateMarketingInfo>,
-    /// This is the address of a cw4 compatible contract that will serve as a whitelist
+    /// This is the address of a tg4 compatible contract that will serve as a whitelist
     pub whitelist_group: String,
 }
 
@@ -114,7 +114,7 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    /// Returns the cw4 contract used to whitelist this token.
+    /// Returns the tg4 contract used to whitelist this token.
     /// Return type: WhitelistResponse
     Whitelist {},
     /// Returns true if the address is in the Whitelist contract.

--- a/contracts/trusted-token/src/multitest/suite.rs
+++ b/contracts/trusted-token/src/multitest/suite.rs
@@ -158,6 +158,7 @@ impl Suite {
                     add: vec![Member {
                         addr: addr.to_string(),
                         points,
+                        start_height: None,
                     }],
                     remove: vec![],
                 },
@@ -474,6 +475,7 @@ impl Config {
                 let member = Member {
                     addr: member.addr.to_string(),
                     points: member.points,
+                    start_height: None,
                 };
                 Ok((member, initial_cash))
             })

--- a/packages/mocks/Cargo.toml
+++ b/packages/mocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfi-mocks"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Confio GmbH"]
 edition = "2018"
 description = "Mocks for tfi tests"
@@ -11,7 +11,7 @@ homepage = "https://tgrade.finance"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tfi = { path = "../tfi", version = "0.3.2" }
+tfi = { path = "../tfi", version = "0.4.0" }
 cw20 = "0.13.4"
 cosmwasm-storage = "1.0.0"
 cosmwasm-std = "1.0.0"

--- a/packages/mocks/Cargo.toml
+++ b/packages/mocks/Cargo.toml
@@ -12,8 +12,8 @@ homepage = "https://tgrade.finance"
 
 [dependencies]
 tfi = { path = "../tfi", version = "0.3.2" }
-cw20 = "0.13.2"
-cosmwasm-storage = "1.0.0-beta8"
-cosmwasm-std = "1.0.0-beta8"
+cw20 = "0.13.4"
+cosmwasm-storage = "1.0.0"
+cosmwasm-std = "1.0.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/tfi/Cargo.toml
+++ b/packages/tfi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfi"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Confio GmbH"]
 edition = "2018"
 description = "Common tfi types"
@@ -24,4 +24,4 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
-tfi-mocks = { path = "../mocks", version = "0.3.2" }
+tfi-mocks = { path = "../mocks", version = "0.4.0" }

--- a/packages/tfi/Cargo.toml
+++ b/packages/tfi/Cargo.toml
@@ -16,12 +16,12 @@ homepage = "https://tgrade.finance"
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = "0.13.2"
-cosmwasm-storage = "1.0.0-beta8"
-cosmwasm-std = "1.0.0-beta8"
+cw20 = "0.13.4"
+cosmwasm-storage = "1.0.0"
+cosmwasm-std = "1.0.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0-beta8"
+cosmwasm-schema = "1.0.0"
 tfi-mocks = { path = "../mocks", version = "0.3.2" }


### PR DESCRIPTION
Update the tfi contracts to the latest versions of cosmwasm and cw-plus.

~~Requires poe-contracts v0.10.0 (https://github.com/confio/poe-contracts/pull/145 and https://github.com/confio/poe-contracts/pull/144)~~. (done)